### PR TITLE
Fix hybrid mode not applying dampen in Flux2KleinEnhancer

### DIFF
--- a/flux2_klein_enhancer.py
+++ b/flux2_klein_enhancer.py
@@ -192,7 +192,7 @@ class Flux2KleinEnhancer:
             # ============================================================
             # DAMPEN MODE: Apply preservation BEFORE modifications
             # ============================================================
-            if preserve_mode == "dampen" and preserve_original != 0.0:
+            if preserve_mode in ["dampen", "hybrid"] and preserve_original != 0.0:
                 # Calculate dampening factors for all operations
                 damping = 1.0 - preserve_original
                 
@@ -444,7 +444,7 @@ class Flux2KleinDetailController:
             # ============================================================
             # DAMPEN MODE: Apply preservation BEFORE regional operations
             # ============================================================
-            if preserve_mode == "dampen" and preserve_original != 0.0:
+            if preserve_mode in ["dampen", "hybrid"] and preserve_original != 0.0:
                 # Dampen the regional multipliers based on preserve_original
                 damping = 1.0 - preserve_original
                 


### PR DESCRIPTION
This pull request fixes the behavior of the hybrid mode in the Flux2KleinEnhancer node.

The Readme describes hybrid as:

"Dampens parameters first, then blends the result."

Previously, the hybrid mode did not properly implement the intended behavior of dampening parameters first and then blending the result. Resulting in Hybrid mode being no different than Linear and Blend_after. 

Now the dampening logic is applied and results in the behavior expected. 

