### PR TITLE
Fix cache invalidation for deterministic nodes

### DIFF
--- a/identity_feature_transfer.py
+++ b/identity_feature_transfer.py
@@ -538,7 +538,7 @@ class IdentityFeatureTransferV3:
 
     @classmethod
     def IS_CHANGED(cls, **kwargs):
-        return float("NaN")
+        return False
 
     @staticmethod
     def _parse_schedule(text, max_block):
@@ -846,7 +846,7 @@ class IdentityFeatureTransferFinal:
 
     @classmethod
     def IS_CHANGED(cls, **kwargs):
-        return float("NaN")
+        return False
 
     @staticmethod
     def _parse_ref_indices(text: str, count: int) -> List[int]:

--- a/multi_reference_latent.py
+++ b/multi_reference_latent.py
@@ -37,7 +37,7 @@ class MultiReferenceLatent:
 
     @classmethod
     def IS_CHANGED(cls, **kwargs):
-        return float("NaN")
+        return False
 
     def apply(self, conditioning, latent_1, **optional):
         refs = []


### PR DESCRIPTION
## Summary

- make deterministic identity/reference helper nodes cacheable by returning a stable `IS_CHANGED` fingerprint
- fix repeated reruns of unchanged upstream stages in multi-stage workflows when only a downstream sampler changes

## Root Cause

`IdentityFeatureTransferV3`, `IdentityFeatureTransferFinal`, and `Flux2KleinMultiReferenceLatent` returned `float("NaN")` from `IS_CHANGED`. In ComfyUI, that marks the node as changed on every queued prompt, which invalidates downstream cache entries even when inputs, widgets, links, and fixed seeds are unchanged.

ComfyUI already includes the node class, widget/input values, and linked ancestors in the cache signature, so returning `False` here still allows normal invalidation when actual inputs change.

## Validation

```bash
python3 -m py_compile identity_feature_transfer.py multi_reference_latent.py
```
